### PR TITLE
fix(deploy): repair the image build, then automate the fly.io deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,76 @@ jobs:
         working-directory: frontend
         env:
           CI: true
+
+  # Builds the container image and throws it away.
+  #
+  # The image is what a deploy ships, and until this job existed nothing checked
+  # it. The `backend` job runs ./gradlew against the runner's own checkout, where
+  # every module directory exists. The Dockerfile instead copies each module
+  # build file by name, so a module added to settings.gradle.kts and forgotten
+  # there is invisible to every test. That broke a deploy on 2026-08-24. This job
+  # is what sees it next time.
+  #
+  # Pull requests only. A push to main goes straight to `deploy`, which builds the
+  # same Dockerfile itself, so running this too would build the image twice.
+  image:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # Deploys to fly.io on every merge to main.
+  deploy:
+    if: github.event_name == 'push'
+    needs: [backend, frontend]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    concurrency:
+      # Two merges close together queue, and the second waits. A deploy in flight
+      # is never cancelled: flyctl stopped part way through a release leaves the
+      # app in a state this workflow cannot reason about.
+      group: deploy-main
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      # fly.io documents `--remote-only`. This uses `--local-only` on purpose.
+      # A remote builder is a fly machine that costs money while it runs, and
+      # docs/deploy.md §4 records the decision to avoid one. A GitHub runner has
+      # its own Docker daemon, so it builds the image and pushes the result to
+      # registry.fly.io without a builder machine.
+      #
+      # `--ha=false` is not optional. Without it flyctl creates two machines on a
+      # release. docs/deploy.md §4 records that `min_machines_running = 0` does
+      # not prevent it.
+      - name: Deploy to fly.io
+        run: flyctl deploy --local-only --ha=false
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      # fly rolls a release back by itself when the health check never passes, and
+      # it does that quietly. This step turns that silence into a red run.
+      # fly.toml gives the check a 10s grace period, so six tries at 10s is ample
+      # for a JVM start plus a cold Atlas handshake.
+      - name: Prove the deployed app is healthy
+        run: |
+          for attempt in 1 2 3 4 5 6; do
+            if curl -sf --max-time 10 https://mytetz.fly.dev/api/health; then
+              echo
+              echo "The deployed app reports healthy."
+              exit 0
+            fi
+            echo "Attempt ${attempt} found no healthy response. Waiting 10s."
+            sleep 10
+          done
+          echo "The deployed app never reported healthy."
+          exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,14 @@ ENV GRADLE_USER_HOME=/gradle-home \
 #      Gradle distribution and every already-downloaded artifact are still there.
 # gradlew is committed with LF and the executable bit, but --chmod makes the
 # build independent of how the host checked it out.
+#
+# This list must name every module that settings.gradle.kts includes. Gradle
+# configures every included project during the resolve step below, and it fails
+# on a project whose directory is absent. A module added to settings.gradle.kts
+# and forgotten here broke a deploy on 2026-08-24: the CI job runs ./gradlew on
+# the runner checkout, where every directory exists, so nothing caught it. The
+# `image` job in .github/workflows/ci.yml now builds this file on every pull
+# request, which is what stops the list going stale unnoticed.
 COPY --chmod=0755 gradlew ./
 COPY gradle ./gradle
 COPY settings.gradle.kts build.gradle.kts ./
@@ -50,6 +58,8 @@ COPY backend/llm/build.gradle.kts         ./backend/llm/
 COPY backend/catalog/build.gradle.kts     ./backend/catalog/
 COPY backend/graph/build.gradle.kts       ./backend/graph/
 COPY backend/quota/build.gradle.kts       ./backend/quota/
+COPY backend/account/build.gradle.kts     ./backend/account/
+COPY backend/billing/build.gradle.kts     ./backend/billing/
 COPY backend/session/build.gradle.kts     ./backend/session/
 COPY backend/assess/build.gradle.kts      ./backend/assess/
 COPY backend/api/build.gradle.kts         ./backend/api/


### PR DESCRIPTION
Repairs a broken image build, then automates the deploy so the repair cannot go unnoticed again.

## Why this exists

A manual `fly deploy` failed at the dependency-warming layer:

```
Configuring project ':backend:account' without an existing directory is not allowed.
The configured projectDirectory '/src/backend/account' does not exist
```

Gradle configures every included project during `:backend:api:dependencies`. `settings.gradle.kts` includes ten modules. The Dockerfile copied eight build files. `:backend:account` and `:backend:billing` arrived with the monetization slices, and that list never followed them.

**No test could see it.** The `backend` job runs `./gradlew` against the runner's own checkout, where every module directory exists. Nothing in CI built the image, so the first thing to notice was a deploy.

## The two commits

### 1. The Dockerfile fix

Two `COPY` lines, for `backend/account` and `backend/billing`, in the order `settings.gradle.kts` uses. A comment above the list records the constraint and the date it broke.

### 2. The workflow

| Job | Trigger | Does |
|---|---|---|
| `image` | Pull request only | `docker build`, and keeps nothing. This is what finds the next drift. |
| `deploy` | Push to main, after `backend` and `frontend` pass | `flyctl deploy --local-only --ha=false`, then polls `/api/health`. |

`image` skips a push to main, because `deploy` builds the same Dockerfile there.

## Three choices that need a reason

| Choice | Reason |
|---|---|
| `--local-only`, not the documented `--remote-only` | A remote builder is a fly machine that costs money while it runs. `docs/deploy.md` §4 records the decision to avoid one. A GitHub runner has its own Docker daemon, so it builds the image and pushes the result to `registry.fly.io` without a builder machine. |
| `--ha=false` | Without it flyctl creates two machines on a release. `docs/deploy.md` §4 records that `min_machines_running = 0` does not stop it. |
| `cancel-in-progress: false` | A second merge waits. flyctl stopped part way through a release leaves the app in a state this workflow cannot reason about. |

The last step polls `/api/health` six times at 10 second intervals. fly rolls a failed release back on its own and says nothing about it, so without this step a bad deploy leaves a green run.

## Verification

| Check | Command | Result |
|---|---|---|
| The failure reproduces | `docker build --target backend .` | Failed in 5 seconds at `Dockerfile:56`, with the same message the deploy gave |
| The fix works | `docker build --target backend .` | `DONE` |
| The whole image builds | `docker build .` | `DONE`, 112 MB on disk |
| The image carries this branch's frontend | `cat /frontend/dist/frontend/browser/index.html` inside the image | `<title>mytetz</title>` plus the three icon links, and `icon.svg`, `favicon.ico` and `apple-touch-icon.png` all present |
| The workflow parses | `yaml.safe_load` | Four jobs. `deploy` carries `needs: [backend, frontend]`, `concurrency: deploy-main` with `cancel-in-progress: false`, and `permissions: contents: read` |

The `image` job in this pull request is itself the live proof of the Dockerfile fix.

## Before you merge

The `FLY_API_TOKEN` repository secret is set. `gh secret list` confirms it.

## After the first deploy

Purge `favicon.ico` at Cloudflare. The only cache rule bypasses `/api/*`, so everything else takes the default, which caches by file extension. `icon.svg` and `apple-touch-icon.png` are new files with no cached copy. `favicon.ico` existed before, so the edge can keep serving the old Angular icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
