### PR TITLE
ci: move the four Node 20 actions off the deprecated runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,21 +7,25 @@ jobs:
   backend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v6
         with: { distribution: temurin, java-version: '21' }
       # :backend:api:processResources builds the Angular bundle into the jar, so the backend
       # job needs a pinned Node too rather than whatever the runner image happens to ship.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with: { node-version: '22', cache: npm, cache-dependency-path: frontend/package-lock.json }
-      - uses: gradle/actions/setup-gradle@v4
+      # v5 and not v6 on purpose. v6 moves the caching component out of open
+      # source, and it makes the workflow accept the Gradle Terms of Use. v5 is
+      # the newest major that clears the Node 20 deprecation and leaves the
+      # licence as it is. See https://blog.gradle.org/github-actions-for-gradle-v6
+      - uses: gradle/actions/setup-gradle@v5
       - run: ./gradlew build --no-daemon
 
   frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with: { node-version: '22', cache: npm, cache-dependency-path: frontend/package-lock.json }
       - run: npm ci
         working-directory: frontend
@@ -60,7 +64,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: docker/setup-buildx-action@v3
       - uses: docker/build-push-action@v6
         with:
@@ -83,7 +87,7 @@ jobs:
       group: deploy-main
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       # fly.io documents `--remote-only`. This uses `--local-only` on purpose.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v6
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/build-push-action@v7
         with:
           context: .
           push: false


### PR DESCRIPTION
Clears the Node 20 deprecation warning that every CI run raises.

GitHub forces an action that targets Node 20 onto Node 24, and it warns each time. Six actions were affected in total, found in two passes.

## The bumps

| Action | From | To | Why that major |
|---|---|---|---|
| `actions/checkout` | v4 | **v7** | Current. v7 changes only `pull_request_target` and `workflow_run` behaviour, and this workflow uses neither. |
| `actions/setup-node` | v4 | **v7** | Current. v7 adds two cache-key outputs and moves to ESM. Nothing here reads either. |
| `actions/setup-java` | v4 | **v6** | Current. The v6 notes call the ESM migration not user facing. The Zulu to Azul metadata change reaches the `zulu` distribution, and this job asks for `temurin`. The `jdkFile` rename keeps a deprecated alias, and this job does not set it. |
| `gradle/actions/setup-gradle` | v4 | **v5** | Not v6. See below. |
| `docker/setup-buildx-action` | v3 | **v4** | Node 24. It removes deprecated inputs and outputs, and this job sets none of them. |
| `docker/build-push-action` | v6 | **v7** | Node 24. It removes two environment variables and the legacy summary tool. This job sets `context`, `push`, `cache-from` and `cache-to`, and no environment variable. |

## Why the docker pair needed a second commit

The first commit reported that neither docker action appeared in the warning. That reading was right about the run it read and wrong as a conclusion.

That run was a **push to main**, where the `image` job does not run. The two actions never executed, so they never warned. The pull request run executed them, and both appeared. The second commit takes them.

## Why gradle/actions stops at v5

`gradle/actions@v6` moves its caching component out of open source, and an upgrade accepts the [Gradle Terms of Use](https://gradle.com/legal/terms-of-use/). See [the Gradle post](https://blog.gradle.org/github-actions-for-gradle-v6).

That is a licensing decision and not a maintenance one, so this PR does not take it. **v5 is the newest major that clears the deprecation and leaves the licence as it is.** A comment in the workflow records the reason, so the next reader does not bump it without knowing.

Take v6 in a later change if you accept those terms. It is one line.

## Verification

| Check | Result |
|---|---|
| The workflow parses | Four jobs, every step intact |
| No `@v4` action remains | Confirmed |
| The `image` job sets no removed input | It sets `context`, `push`, `cache-from`, `cache-to` only |
| The warning is gone | Only a run can prove this. The checks on this pull request are the proof. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
